### PR TITLE
Add FastAPI modular monolith project scaffold

### DIFF
--- a/fastapi-modmonolith/.env.example
+++ b/fastapi-modmonolith/.env.example
@@ -1,0 +1,39 @@
+# FastAPI
+APP_ENV=dev
+APP_DEBUG=true
+APP_HOST=0.0.0.0
+APP_PORT=8000
+
+# Database
+DB_HOST=db
+DB_PORT=5432
+DB_USER=app
+DB_PASSWORD=app
+DB_NAME=app
+DB_ECHO=false
+
+# Redis (für Streams, optional)
+REDIS_HOST=redis
+REDIS_PORT=6379
+
+# Tenancy
+TENANCY_MODE=row
+TENANCY_HEADER=X-Tenant-Id
+TENANCY_DEFAULT=public
+
+# OIDC (DEV-Hook)
+OIDC_ENABLED=true
+OIDC_ISSUER=https://dev-issuer.example
+OIDC_AUDIENCE=app-api
+OIDC_JWKS_PATH=/mnt/dev-jwks.json   # wird im Container gemountet
+
+# Dev JWT Test-User (nur lokal!)
+DEV_JWT_SUB=00000000-0000-0000-0000-000000000001
+DEV_JWT_EMAIL=alice@example.com
+DEV_TENANT=acme
+
+# Security
+JWT_ALG=RS256
+
+# Outbox Worker
+OUTBOX_POLL_MS=500

--- a/fastapi-modmonolith/Dockerfile
+++ b/fastapi-modmonolith/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY pyproject.toml ./
+RUN pip install --no-cache-dir --upgrade pip
+
+COPY . ./
+RUN pip install --no-cache-dir .
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/fastapi-modmonolith/Makefile
+++ b/fastapi-modmonolith/Makefile
@@ -1,0 +1,16 @@
+.PHONY: run worker format lint migrate
+
+run:
+	uvicorn app.main:app --reload
+
+worker:
+	python -m app.worker.outbox_worker
+
+format:
+	black app
+
+lint:
+	ruff check app
+
+migrate:
+	alembic upgrade head

--- a/fastapi-modmonolith/README.md
+++ b/fastapi-modmonolith/README.md
@@ -1,0 +1,30 @@
+# FastAPI Modular Monolith
+
+Dieses Projekt bietet ein Grundgerüst für einen modularen Monolithen mit FastAPI, Domain Driven Design und einem einfachen In-Process-Messagebus. Die Struktur ermöglicht die Trennung von Domänen, Application Layer, Infrastruktur und Präsentation.
+
+## Features
+
+- FastAPI mit orjson als Standard-Response
+- SQLAlchemy 2.0 & Alembic für Datenbankzugriff und Migrationen
+- Asynchrone PostgreSQL Treiber (asyncpg) und psycopg für Alembic
+- Structlog für strukturierte Logs
+- OIDC Hook mit Authlib und python-jose
+- Redis & fastapi-limiter vorbereitet für spätere Ratenbegrenzung und Streams
+- Tenancy Middleware über HTTP Header
+- Einfacher Outbox-Worker als Platzhalter
+
+## Entwicklung
+
+```bash
+make run        # startet die FastAPI App
+make worker     # startet den Outbox Worker
+make migrate    # führt Alembic Migrationen aus
+```
+
+## Docker
+
+```bash
+docker-compose up --build
+```
+
+Die Anwendung erwartet eine `.env` Datei basierend auf `.env.example`.

--- a/fastapi-modmonolith/alembic.ini
+++ b/fastapi-modmonolith/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = postgresql+psycopg://app:app@db:5432/app
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/fastapi-modmonolith/app/__init__.py
+++ b/fastapi-modmonolith/app/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI modular monolith application package."""
+
+from .main import create_app
+
+__all__ = ["create_app"]

--- a/fastapi-modmonolith/app/config.py
+++ b/fastapi-modmonolith/app/config.py
@@ -1,0 +1,55 @@
+"""Application configuration using Pydantic settings."""
+
+from functools import lru_cache
+from typing import Literal
+
+from pydantic import AnyHttpUrl, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Typed configuration loaded from environment variables."""
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+    app_env: Literal["dev", "prod", "test"] = Field(default="dev", validation_alias="APP_ENV")
+    app_debug: bool = Field(default=True, validation_alias="APP_DEBUG")
+    app_host: str = Field(default="0.0.0.0", validation_alias="APP_HOST")
+    app_port: int = Field(default=8000, validation_alias="APP_PORT")
+
+    db_host: str = Field(default="localhost", validation_alias="DB_HOST")
+    db_port: int = Field(default=5432, validation_alias="DB_PORT")
+    db_user: str = Field(default="app", validation_alias="DB_USER")
+    db_password: str = Field(default="app", validation_alias="DB_PASSWORD")
+    db_name: str = Field(default="app", validation_alias="DB_NAME")
+    db_echo: bool = Field(default=False, validation_alias="DB_ECHO")
+
+    redis_host: str = Field(default="localhost", validation_alias="REDIS_HOST")
+    redis_port: int = Field(default=6379, validation_alias="REDIS_PORT")
+
+    tenancy_mode: Literal["row", "schema"] = Field(default="row", validation_alias="TENANCY_MODE")
+    tenancy_header: str = Field(default="X-Tenant-Id", validation_alias="TENANCY_HEADER")
+    tenancy_default: str = Field(default="public", validation_alias="TENANCY_DEFAULT")
+
+    oidc_enabled: bool = Field(default=True, validation_alias="OIDC_ENABLED")
+    oidc_issuer: AnyHttpUrl | None = Field(default=None, validation_alias="OIDC_ISSUER")
+    oidc_audience: str | None = Field(default=None, validation_alias="OIDC_AUDIENCE")
+    oidc_jwks_path: str | None = Field(default=None, validation_alias="OIDC_JWKS_PATH")
+
+    dev_jwt_sub: str | None = Field(default=None, validation_alias="DEV_JWT_SUB")
+    dev_jwt_email: str | None = Field(default=None, validation_alias="DEV_JWT_EMAIL")
+    dev_tenant: str | None = Field(default=None, validation_alias="DEV_TENANT")
+
+    jwt_alg: str = Field(default="RS256", validation_alias="JWT_ALG")
+
+    outbox_poll_ms: int = Field(default=500, validation_alias="OUTBOX_POLL_MS")
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return cached settings instance."""
+
+    return Settings()
+
+
+__all__ = ["Settings", "get_settings"]

--- a/fastapi-modmonolith/app/logging.py
+++ b/fastapi-modmonolith/app/logging.py
@@ -1,0 +1,44 @@
+"""Central logging configuration for the application."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import structlog
+
+
+def configure_logging(debug: bool = False) -> None:
+    """Configure structlog and standard logging."""
+
+    timestamper = structlog.processors.TimeStamper(fmt="iso")
+    shared_processors: list[structlog.types.Processor] = [
+        timestamper,
+        structlog.processors.add_log_level,
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+    ]
+
+    structlog.configure(
+        processors=[
+            *shared_processors,
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.DEBUG if debug else logging.INFO),
+        cache_logger_on_first_use=True,
+    )
+
+    logging.basicConfig(
+        level=logging.DEBUG if debug else logging.INFO,
+        format="%(message)s",
+        stream=sys.stdout,
+    )
+
+
+def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
+    """Return a structlog logger bound to the given name."""
+
+    logger = structlog.stdlib.get_logger(name)
+    return logger.bind()
+
+
+__all__ = ["configure_logging", "get_logger"]

--- a/fastapi-modmonolith/app/main.py
+++ b/fastapi-modmonolith/app/main.py
@@ -1,0 +1,60 @@
+"""FastAPI application factory."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.responses import ORJSONResponse
+
+from .config import Settings, get_settings
+from .logging import configure_logging, get_logger
+from .shared.messagebus import MessageBus
+from .shared.tenancy.middleware import TenantContextMiddleware
+
+
+@asynccontextmanager
+def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Application startup/shutdown hooks."""
+
+    logger = get_logger(__name__)
+    settings = get_settings()
+    configure_logging(debug=settings.app_debug)
+    logger.info("application_startup", env=settings.app_env)
+    messagebus = MessageBus()
+    app.state.messagebus = messagebus
+    yield
+    logger.info("application_shutdown")
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    """Create and configure the FastAPI application."""
+
+    settings = settings or get_settings()
+    app = FastAPI(
+        title="FastAPI Modular Monolith",
+        version="0.1.0",
+        default_response_class=ORJSONResponse,
+        lifespan=lifespan,
+    )
+
+    app.add_middleware(TenantContextMiddleware, header=settings.tenancy_header, default_tenant=settings.tenancy_default)
+
+    @app.get("/health", tags=["system"])
+    async def health_check() -> dict[str, str]:
+        return {"status": "ok"}
+
+    from .modules.users.presentation.http.routers import router as users_router
+    from .modules.blog.presentation.http.routers import router as blog_router
+
+    app.include_router(users_router, prefix="/users")
+    app.include_router(blog_router, prefix="/blog")
+
+    return app
+
+
+app = create_app()
+
+
+__all__ = ["create_app", "app"]

--- a/fastapi-modmonolith/app/modules/blog/__init__.py
+++ b/fastapi-modmonolith/app/modules/blog/__init__.py
@@ -1,0 +1,1 @@
+"""Blog bounded context."""

--- a/fastapi-modmonolith/app/modules/blog/application/__init__.py
+++ b/fastapi-modmonolith/app/modules/blog/application/__init__.py
@@ -1,0 +1,7 @@
+"""Application layer for blog."""
+
+from .commands import PublishPost
+from .handlers import list_posts_handler, publish_post_handler
+from .queries import ListPosts
+
+__all__ = ["PublishPost", "publish_post_handler", "list_posts_handler", "ListPosts"]

--- a/fastapi-modmonolith/app/modules/blog/application/commands.py
+++ b/fastapi-modmonolith/app/modules/blog/application/commands.py
@@ -1,0 +1,16 @@
+"""Blog commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class PublishPost:
+    title: str
+    slug: str
+    body: str
+    tenant_id: str
+
+
+__all__ = ["PublishPost"]

--- a/fastapi-modmonolith/app/modules/blog/application/handlers.py
+++ b/fastapi-modmonolith/app/modules/blog/application/handlers.py
@@ -1,0 +1,35 @@
+"""Handlers for blog commands and queries."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from ..domain.entities import Post
+from ..domain.value_objects import Slug
+from ..infrastructure import InMemoryPostRepository
+from .commands import PublishPost
+from .queries import ListPosts
+
+_repository = InMemoryPostRepository()
+
+
+async def publish_post_handler(command: PublishPost) -> dict:
+    slug = Slug(command.slug)
+    post, _event = Post.publish(title=command.title, body=command.body, slug=slug, tenant_id=command.tenant_id)
+    await _repository.add(post)
+    return {"id": str(post.id), "title": post.title, "slug": str(post.slug)}
+
+
+async def list_posts_handler(query: ListPosts) -> Iterable[dict]:
+    posts = await _repository.list(limit=query.limit)
+    return [
+        {
+            "id": str(post.id),
+            "title": post.title,
+            "slug": str(post.slug),
+        }
+        for post in posts
+    ]
+
+
+__all__ = ["publish_post_handler", "list_posts_handler"]

--- a/fastapi-modmonolith/app/modules/blog/application/queries.py
+++ b/fastapi-modmonolith/app/modules/blog/application/queries.py
@@ -1,0 +1,13 @@
+"""Blog queries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class ListPosts:
+    limit: int = 20
+
+
+__all__ = ["ListPosts"]

--- a/fastapi-modmonolith/app/modules/blog/domain/__init__.py
+++ b/fastapi-modmonolith/app/modules/blog/domain/__init__.py
@@ -1,0 +1,7 @@
+"""Blog domain layer."""
+
+from .entities import Post
+from .events import PostPublished
+from .value_objects import Slug
+
+__all__ = ["Post", "PostPublished", "Slug"]

--- a/fastapi-modmonolith/app/modules/blog/domain/entities.py
+++ b/fastapi-modmonolith/app/modules/blog/domain/entities.py
@@ -1,0 +1,29 @@
+"""Blog domain entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from .events import PostPublished
+from .value_objects import Slug
+
+
+@dataclass(slots=True)
+class Post:
+    id: UUID
+    title: str
+    slug: Slug
+    body: str
+    tenant_id: str
+    published_at: datetime | None = None
+
+    @classmethod
+    def publish(cls, title: str, body: str, slug: Slug, tenant_id: str) -> tuple["Post", PostPublished]:
+        post = cls(id=uuid4(), title=title, slug=slug, body=body, tenant_id=tenant_id, published_at=datetime.utcnow())
+        event = PostPublished(name="post_published", post_id=post.id, tenant_id=tenant_id)
+        return post, event
+
+
+__all__ = ["Post"]

--- a/fastapi-modmonolith/app/modules/blog/domain/events.py
+++ b/fastapi-modmonolith/app/modules/blog/domain/events.py
@@ -1,0 +1,17 @@
+"""Blog domain events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from ....shared.events import Event
+
+
+@dataclass(slots=True)
+class PostPublished(Event):
+    post_id: UUID
+    tenant_id: str
+
+
+__all__ = ["PostPublished"]

--- a/fastapi-modmonolith/app/modules/blog/domain/value_objects.py
+++ b/fastapi-modmonolith/app/modules/blog/domain/value_objects.py
@@ -1,0 +1,20 @@
+"""Value objects for blog posts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Slug:
+    value: str
+
+    def __post_init__(self) -> None:
+        if not self.value or " " in self.value:
+            raise ValueError("Slug must be a non-empty string without spaces")
+
+    def __str__(self) -> str:
+        return self.value
+
+
+__all__ = ["Slug"]

--- a/fastapi-modmonolith/app/modules/blog/infrastructure/__init__.py
+++ b/fastapi-modmonolith/app/modules/blog/infrastructure/__init__.py
@@ -1,0 +1,5 @@
+"""Infrastructure layer for blog module."""
+
+from .repository import InMemoryPostRepository, PostRepository
+
+__all__ = ["PostRepository", "InMemoryPostRepository"]

--- a/fastapi-modmonolith/app/modules/blog/infrastructure/mappers.py
+++ b/fastapi-modmonolith/app/modules/blog/infrastructure/mappers.py
@@ -1,0 +1,18 @@
+"""Mappers for blog domain entities."""
+
+from __future__ import annotations
+
+from ..domain.entities import Post
+
+
+def post_to_dict(post: Post) -> dict:
+    return {
+        "id": str(post.id),
+        "title": post.title,
+        "slug": str(post.slug),
+        "tenant_id": post.tenant_id,
+        "published_at": post.published_at.isoformat() if post.published_at else None,
+    }
+
+
+__all__ = ["post_to_dict"]

--- a/fastapi-modmonolith/app/modules/blog/infrastructure/repository.py
+++ b/fastapi-modmonolith/app/modules/blog/infrastructure/repository.py
@@ -1,0 +1,31 @@
+"""Post repository abstraction."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from typing import Dict
+
+from ..domain.entities import Post
+
+
+class PostRepository(ABC):
+    @abstractmethod
+    async def add(self, post: Post) -> None: ...
+
+    @abstractmethod
+    async def list(self, limit: int = 20) -> Iterable[Post]: ...
+
+
+class InMemoryPostRepository(PostRepository):
+    def __init__(self) -> None:
+        self._posts: Dict[str, Post] = {}
+
+    async def add(self, post: Post) -> None:
+        self._posts[str(post.id)] = post
+
+    async def list(self, limit: int = 20) -> Iterable[Post]:
+        return list(self._posts.values())[:limit]
+
+
+__all__ = ["PostRepository", "InMemoryPostRepository"]

--- a/fastapi-modmonolith/app/modules/blog/presentation/__init__.py
+++ b/fastapi-modmonolith/app/modules/blog/presentation/__init__.py
@@ -1,0 +1,1 @@
+"""Presentation layer for blog."""

--- a/fastapi-modmonolith/app/modules/blog/presentation/http/__init__.py
+++ b/fastapi-modmonolith/app/modules/blog/presentation/http/__init__.py
@@ -1,0 +1,5 @@
+"""HTTP routing for blog."""
+
+from .routers import router
+
+__all__ = ["router"]

--- a/fastapi-modmonolith/app/modules/blog/presentation/http/routers.py
+++ b/fastapi-modmonolith/app/modules/blog/presentation/http/routers.py
@@ -1,0 +1,42 @@
+"""API routes for blog posts."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ....shared.tenancy.context import tenant_context_var
+from ...application.commands import PublishPost
+from ...application.handlers import list_posts_handler, publish_post_handler
+from ...application.queries import ListPosts
+
+router = APIRouter(tags=["blog"])
+
+
+class PostCreateRequest(BaseModel):
+    title: str
+    slug: str
+    body: str
+
+
+class PostResponse(BaseModel):
+    id: str
+    title: str
+    slug: str
+
+
+@router.post("/", response_model=PostResponse, status_code=201)
+async def create_post(payload: PostCreateRequest) -> PostResponse:
+    tenant_context = tenant_context_var.get()
+    if not tenant_context:
+        raise HTTPException(status_code=400, detail="Tenant context missing")
+    result = await publish_post_handler(
+        PublishPost(title=payload.title, slug=payload.slug, body=payload.body, tenant_id=tenant_context.tenant_id)
+    )
+    return PostResponse(**result)
+
+
+@router.get("/", response_model=list[PostResponse])
+async def list_posts(limit: int = 20) -> list[PostResponse]:
+    items = await list_posts_handler(ListPosts(limit=limit))
+    return [PostResponse(**item) for item in items]

--- a/fastapi-modmonolith/app/modules/blog/subscribers/__init__.py
+++ b/fastapi-modmonolith/app/modules/blog/subscribers/__init__.py
@@ -1,0 +1,1 @@
+"""Event subscribers for blog module."""

--- a/fastapi-modmonolith/app/modules/users/__init__.py
+++ b/fastapi-modmonolith/app/modules/users/__init__.py
@@ -1,0 +1,1 @@
+"""Users bounded context."""

--- a/fastapi-modmonolith/app/modules/users/application/__init__.py
+++ b/fastapi-modmonolith/app/modules/users/application/__init__.py
@@ -1,0 +1,7 @@
+"""Application layer for users."""
+
+from .commands import RegisterUser
+from .handlers import list_users_handler, register_user_handler
+from .queries import ListUsers
+
+__all__ = ["RegisterUser", "register_user_handler", "list_users_handler", "ListUsers"]

--- a/fastapi-modmonolith/app/modules/users/application/commands.py
+++ b/fastapi-modmonolith/app/modules/users/application/commands.py
@@ -1,0 +1,14 @@
+"""Command definitions for the users module."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class RegisterUser:
+    email: str
+    tenant_id: str
+
+
+__all__ = ["RegisterUser"]

--- a/fastapi-modmonolith/app/modules/users/application/handlers.py
+++ b/fastapi-modmonolith/app/modules/users/application/handlers.py
@@ -1,0 +1,28 @@
+"""Command and query handlers for users."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from ..domain.services import register_user
+from ..infrastructure import InMemoryUserRepository
+from .commands import RegisterUser
+from .queries import ListUsers
+
+_repository = InMemoryUserRepository()
+
+
+async def register_user_handler(command: RegisterUser) -> dict:
+    result = await register_user(command.email, command.tenant_id)
+    if result.is_failure:
+        raise ValueError(result.error)
+    await _repository.add(result.value)
+    return {"id": str(result.value.id), "email": str(result.value.email)}
+
+
+async def list_users_handler(query: ListUsers) -> Iterable[dict]:
+    users = await _repository.list(limit=query.limit)
+    return [{"id": str(u.id), "email": str(u.email)} for u in users]
+
+
+__all__ = ["register_user_handler", "list_users_handler"]

--- a/fastapi-modmonolith/app/modules/users/application/queries.py
+++ b/fastapi-modmonolith/app/modules/users/application/queries.py
@@ -1,0 +1,13 @@
+"""Query definitions for users."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class ListUsers:
+    limit: int = 20
+
+
+__all__ = ["ListUsers"]

--- a/fastapi-modmonolith/app/modules/users/domain/__init__.py
+++ b/fastapi-modmonolith/app/modules/users/domain/__init__.py
@@ -1,0 +1,7 @@
+"""Domain layer for user management."""
+
+from .entities import User
+from .events import UserRegistered
+from .value_objects import Email
+
+__all__ = ["User", "UserRegistered", "Email"]

--- a/fastapi-modmonolith/app/modules/users/domain/entities.py
+++ b/fastapi-modmonolith/app/modules/users/domain/entities.py
@@ -1,0 +1,29 @@
+"""Domain entities for the users module."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from .events import UserRegistered
+from .value_objects import Email
+
+
+@dataclass(slots=True)
+class User:
+    """Aggregate root representing a system user."""
+
+    id: UUID
+    email: Email
+    tenant_id: str
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+    @classmethod
+    def register(cls, email: Email, tenant_id: str) -> tuple["User", UserRegistered]:
+        user = cls(id=uuid4(), email=email, tenant_id=tenant_id)
+        event = UserRegistered(name="user_registered", user_id=user.id, tenant_id=tenant_id)
+        return user, event
+
+
+__all__ = ["User"]

--- a/fastapi-modmonolith/app/modules/users/domain/events.py
+++ b/fastapi-modmonolith/app/modules/users/domain/events.py
@@ -1,0 +1,19 @@
+"""Domain events for users."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from ....shared.events import Event
+
+
+@dataclass(slots=True)
+class UserRegistered(Event):
+    """Raised when a new user registers."""
+
+    user_id: UUID
+    tenant_id: str
+
+
+__all__ = ["UserRegistered"]

--- a/fastapi-modmonolith/app/modules/users/domain/services.py
+++ b/fastapi-modmonolith/app/modules/users/domain/services.py
@@ -1,0 +1,22 @@
+"""Domain services for users."""
+
+from __future__ import annotations
+
+from ....shared.result import Result
+from .entities import User
+from .value_objects import Email
+
+
+async def register_user(email: str, tenant_id: str) -> Result[User, str]:
+    """Simple domain service to register a user."""
+
+    try:
+        email_vo = Email(email)
+    except ValueError as exc:
+        return Result(error=str(exc))
+
+    user, event = User.register(email_vo, tenant_id)
+    return Result(value=user)
+
+
+__all__ = ["register_user"]

--- a/fastapi-modmonolith/app/modules/users/domain/value_objects.py
+++ b/fastapi-modmonolith/app/modules/users/domain/value_objects.py
@@ -1,0 +1,25 @@
+"""Value objects for the users domain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pydantic import EmailStr, ValidationError
+
+
+@dataclass(frozen=True, slots=True)
+class Email:
+    """Email value object with validation."""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        try:
+            EmailStr(self.value)
+        except ValidationError as exc:  # pragma: no cover - simple example
+            raise ValueError("Invalid email address") from exc
+
+    def __str__(self) -> str:
+        return self.value
+
+
+__all__ = ["Email"]

--- a/fastapi-modmonolith/app/modules/users/infrastructure/__init__.py
+++ b/fastapi-modmonolith/app/modules/users/infrastructure/__init__.py
@@ -1,0 +1,5 @@
+"""Infrastructure layer for users."""
+
+from .repository import InMemoryUserRepository, UserRepository
+
+__all__ = ["UserRepository", "InMemoryUserRepository"]

--- a/fastapi-modmonolith/app/modules/users/infrastructure/mappers.py
+++ b/fastapi-modmonolith/app/modules/users/infrastructure/mappers.py
@@ -1,0 +1,17 @@
+"""Mapping utilities between domain objects and persistence models."""
+
+from __future__ import annotations
+
+from ..domain.entities import User
+
+
+def user_to_dict(user: User) -> dict:
+    return {
+        "id": str(user.id),
+        "email": str(user.email),
+        "tenant_id": user.tenant_id,
+        "created_at": user.created_at.isoformat(),
+    }
+
+
+__all__ = ["user_to_dict"]

--- a/fastapi-modmonolith/app/modules/users/infrastructure/repository.py
+++ b/fastapi-modmonolith/app/modules/users/infrastructure/repository.py
@@ -1,0 +1,35 @@
+"""User repository abstractions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from typing import Dict
+
+from ..domain.entities import User
+
+
+class UserRepository(ABC):
+    """Abstract repository interface."""
+
+    @abstractmethod
+    async def add(self, user: User) -> None: ...
+
+    @abstractmethod
+    async def list(self, limit: int = 20) -> Iterable[User]: ...
+
+
+class InMemoryUserRepository(UserRepository):
+    """Simple repository used during bootstrapping."""
+
+    def __init__(self) -> None:
+        self._users: Dict[str, User] = {}
+
+    async def add(self, user: User) -> None:
+        self._users[str(user.id)] = user
+
+    async def list(self, limit: int = 20) -> Iterable[User]:
+        return list(self._users.values())[:limit]
+
+
+__all__ = ["UserRepository", "InMemoryUserRepository"]

--- a/fastapi-modmonolith/app/modules/users/presentation/__init__.py
+++ b/fastapi-modmonolith/app/modules/users/presentation/__init__.py
@@ -1,0 +1,1 @@
+"""Presentation layer for users (HTTP adapters)."""

--- a/fastapi-modmonolith/app/modules/users/presentation/http/__init__.py
+++ b/fastapi-modmonolith/app/modules/users/presentation/http/__init__.py
@@ -1,0 +1,5 @@
+"""HTTP routing for the users module."""
+
+from .routers import router
+
+__all__ = ["router"]

--- a/fastapi-modmonolith/app/modules/users/presentation/http/routers.py
+++ b/fastapi-modmonolith/app/modules/users/presentation/http/routers.py
@@ -1,0 +1,37 @@
+"""API routes for the users module."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, EmailStr
+
+from ....shared.tenancy.context import tenant_context_var
+from ...application.commands import RegisterUser
+from ...application.handlers import list_users_handler, register_user_handler
+from ...application.queries import ListUsers
+
+router = APIRouter(tags=["users"])
+
+
+class UserCreateRequest(BaseModel):
+    email: EmailStr
+
+
+class UserResponse(BaseModel):
+    id: str
+    email: EmailStr
+
+
+@router.post("/", response_model=UserResponse, status_code=201)
+async def create_user(payload: UserCreateRequest) -> UserResponse:
+    tenant_context = tenant_context_var.get()
+    if not tenant_context:
+        raise HTTPException(status_code=400, detail="Tenant context missing")
+    result = await register_user_handler(RegisterUser(email=payload.email, tenant_id=tenant_context.tenant_id))
+    return UserResponse(**result)
+
+
+@router.get("/", response_model=list[UserResponse])
+async def list_users(limit: int = 20) -> list[UserResponse]:
+    items = await list_users_handler(ListUsers(limit=limit))
+    return [UserResponse(**item) for item in items]

--- a/fastapi-modmonolith/app/modules/users/subscribers/__init__.py
+++ b/fastapi-modmonolith/app/modules/users/subscribers/__init__.py
@@ -1,0 +1,1 @@
+"""Event subscribers for the users module."""

--- a/fastapi-modmonolith/app/modules/users/subscribers/on_user_registered.py
+++ b/fastapi-modmonolith/app/modules/users/subscribers/on_user_registered.py
@@ -1,0 +1,15 @@
+"""Example subscriber for the user registered event."""
+
+from __future__ import annotations
+
+from ....shared.logging import get_logger
+from ..domain.events import UserRegistered
+
+logger = get_logger(__name__)
+
+
+async def on_user_registered(event: UserRegistered) -> None:
+    logger.info("user_registered", user_id=str(event.user_id), tenant_id=event.tenant_id)
+
+
+__all__ = ["on_user_registered"]

--- a/fastapi-modmonolith/app/shared/__init__.py
+++ b/fastapi-modmonolith/app/shared/__init__.py
@@ -1,0 +1,18 @@
+"""Shared building blocks for the modular monolith."""
+
+from .db import SessionFactory, engine, get_session
+from .events import Event, EventHandler
+from .messagebus import MessageBus
+from .result import Result
+from .uow import AbstractUnitOfWork
+
+__all__ = [
+    "SessionFactory",
+    "engine",
+    "get_session",
+    "Event",
+    "EventHandler",
+    "MessageBus",
+    "Result",
+    "AbstractUnitOfWork",
+]

--- a/fastapi-modmonolith/app/shared/db.py
+++ b/fastapi-modmonolith/app/shared/db.py
@@ -1,0 +1,26 @@
+"""Database configuration and session helpers."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+
+from ..config import get_settings
+
+
+settings = get_settings()
+DATABASE_URL = f"postgresql+asyncpg://{settings.db_user}:{settings.db_password}@{settings.db_host}:{settings.db_port}/{settings.db_name}"
+
+engine: AsyncEngine = create_async_engine(DATABASE_URL, echo=settings.db_echo, future=True)
+SessionFactory = async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def get_session() -> AsyncIterator[AsyncSession]:
+    """FastAPI dependency that yields a database session."""
+
+    async with SessionFactory() as session:
+        yield session
+
+
+__all__ = ["engine", "SessionFactory", "get_session", "DATABASE_URL"]

--- a/fastapi-modmonolith/app/shared/events.py
+++ b/fastapi-modmonolith/app/shared/events.py
@@ -1,0 +1,23 @@
+"""Simple in-process domain events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(slots=True)
+class Event:
+    """Base class for domain events."""
+
+    name: str
+
+
+@runtime_checkable
+class EventHandler(Protocol):
+    """Protocol for event handlers."""
+
+    async def __call__(self, event: Event) -> None: ...
+
+
+__all__ = ["Event", "EventHandler"]

--- a/fastapi-modmonolith/app/shared/messagebus.py
+++ b/fastapi-modmonolith/app/shared/messagebus.py
@@ -1,0 +1,41 @@
+"""In-process message bus for commands and events."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Awaitable, Callable
+
+from .events import Event, EventHandler
+
+
+Handler = Callable[[Any], Awaitable[Any]]
+
+
+class MessageBus:
+    """Async message bus supporting command and event dispatch."""
+
+    def __init__(self) -> None:
+        self._event_handlers: dict[type[Event], list[EventHandler]] = defaultdict(list)
+        self._command_handlers: dict[type[Any], Handler] = {}
+
+    def register_event_handler(self, event_type: type[Event], handler: EventHandler) -> None:
+        self._event_handlers[event_type].append(handler)
+
+    def register_command_handler(self, command_type: type[Any], handler: Handler) -> None:
+        self._command_handlers[command_type] = handler
+
+    async def handle(self, message: Any) -> Any:
+        handler = self._command_handlers.get(type(message))
+        if handler:
+            return await handler(message)
+        if isinstance(message, Event):
+            await self._handle_event(message)
+            return None
+        raise ValueError(f"No handler registered for message type {type(message)!r}")
+
+    async def _handle_event(self, event: Event) -> None:
+        for handler in self._event_handlers.get(type(event), []):
+            await handler(event)
+
+
+__all__ = ["MessageBus"]

--- a/fastapi-modmonolith/app/shared/outbox.py
+++ b/fastapi-modmonolith/app/shared/outbox.py
@@ -1,0 +1,24 @@
+"""Simplified transactional outbox placeholder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID, uuid4
+
+
+@dataclass(slots=True)
+class OutboxMessage:
+    """Represents a message waiting to be published."""
+
+    id: UUID
+    topic: str
+    payload: dict
+    created_at: datetime
+
+    @classmethod
+    def create(cls, topic: str, payload: dict) -> "OutboxMessage":
+        return cls(id=uuid4(), topic=topic, payload=payload, created_at=datetime.utcnow())
+
+
+__all__ = ["OutboxMessage"]

--- a/fastapi-modmonolith/app/shared/result.py
+++ b/fastapi-modmonolith/app/shared/result.py
@@ -1,0 +1,28 @@
+"""Utility result type for application service responses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+E = TypeVar("E")
+
+
+@dataclass(slots=True)
+class Result(Generic[T, E]):
+    """Represents success or failure."""
+
+    value: T | None = None
+    error: E | None = None
+
+    @property
+    def is_success(self) -> bool:
+        return self.error is None
+
+    @property
+    def is_failure(self) -> bool:
+        return not self.is_success
+
+
+__all__ = ["Result"]

--- a/fastapi-modmonolith/app/shared/security/__init__.py
+++ b/fastapi-modmonolith/app/shared/security/__init__.py
@@ -1,0 +1,6 @@
+"""Security helpers (OIDC integration, cryptography)."""
+
+from .oidc import OIDCVerifier
+from .crypto import read_jwks
+
+__all__ = ["OIDCVerifier", "read_jwks"]

--- a/fastapi-modmonolith/app/shared/security/crypto.py
+++ b/fastapi-modmonolith/app/shared/security/crypto.py
@@ -1,0 +1,17 @@
+"""Crypto utilities used by the OIDC verifier."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def read_jwks(path: str | Path) -> dict[str, Any]:
+    """Read a JWKS file from disk."""
+
+    with Path(path).expanduser().open("r", encoding="utf-8") as fp:
+        return json.load(fp)
+
+
+__all__ = ["read_jwks"]

--- a/fastapi-modmonolith/app/shared/security/oidc.py
+++ b/fastapi-modmonolith/app/shared/security/oidc.py
@@ -1,0 +1,51 @@
+"""OIDC token verification helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from authlib.jose import JsonWebToken
+from authlib.jose.errors import JoseError
+from jose import jwt
+
+from ..config import get_settings
+from .crypto import read_jwks
+
+
+class OIDCVerifier:
+    """Very small wrapper around Authlib and python-jose for development use."""
+
+    def __init__(self, jwks_path: str | None = None) -> None:
+        settings = get_settings()
+        self.issuer = settings.oidc_issuer
+        self.audience = settings.oidc_audience
+        self.jwt_alg = settings.jwt_alg
+        path_value = jwks_path or settings.oidc_jwks_path
+        self.jwks_path = Path(path_value) if path_value else None
+        self._jwt = JsonWebToken([self.jwt_alg])
+
+    def load_keys(self) -> dict:
+        if not self.jwks_path:
+            raise RuntimeError("JWKS path is not configured")
+        return read_jwks(self.jwks_path)
+
+    def verify(self, token: str) -> dict:
+        try:
+            jwks = self.load_keys()
+            return self._jwt.decode(
+                token,
+                jwks,
+                claims_options={"iss": {"values": [self.issuer]}, "aud": {"values": [self.audience]}},
+            )
+        except JoseError:
+            # fallback to python-jose for local debugging
+            return jwt.decode(
+                token,
+                self.load_keys(),
+                algorithms=[self.jwt_alg],
+                audience=self.audience,
+                issuer=self.issuer,
+            )
+
+
+__all__ = ["OIDCVerifier"]

--- a/fastapi-modmonolith/app/shared/tenancy/__init__.py
+++ b/fastapi-modmonolith/app/shared/tenancy/__init__.py
@@ -1,0 +1,6 @@
+"""Tenancy utilities for the modular monolith."""
+
+from .context import TenantContext, tenant_context_var
+from .middleware import TenantContextMiddleware
+
+__all__ = ["TenantContext", "tenant_context_var", "TenantContextMiddleware"]

--- a/fastapi-modmonolith/app/shared/tenancy/context.py
+++ b/fastapi-modmonolith/app/shared/tenancy/context.py
@@ -1,0 +1,19 @@
+"""Context var to hold current tenant information."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class TenantContext:
+    """Represents the active tenant in the request scope."""
+
+    tenant_id: str
+
+
+tenant_context_var: ContextVar[TenantContext | None] = ContextVar("tenant_context", default=None)
+
+
+__all__ = ["TenantContext", "tenant_context_var"]

--- a/fastapi-modmonolith/app/shared/tenancy/middleware.py
+++ b/fastapi-modmonolith/app/shared/tenancy/middleware.py
@@ -1,0 +1,32 @@
+"""Tenant resolution middleware."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+from .context import TenantContext, tenant_context_var
+
+
+class TenantContextMiddleware(BaseHTTPMiddleware):
+    """Populate the tenant context for each request."""
+
+    def __init__(self, app: ASGIApp, header: str = "X-Tenant-Id", default_tenant: str = "public") -> None:
+        super().__init__(app)
+        self.header = header
+        self.default_tenant = default_tenant
+
+    async def dispatch(self, request: Request, call_next: Callable):  # type: ignore[override]
+        tenant_id = request.headers.get(self.header, self.default_tenant)
+        token = tenant_context_var.set(TenantContext(tenant_id=tenant_id))
+        try:
+            response = await call_next(request)
+        finally:
+            tenant_context_var.reset(token)
+        return response
+
+
+__all__ = ["TenantContextMiddleware"]

--- a/fastapi-modmonolith/app/shared/uow.py
+++ b/fastapi-modmonolith/app/shared/uow.py
@@ -1,0 +1,46 @@
+"""Unit of work abstractions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .db import SessionFactory
+
+
+class AbstractUnitOfWork(ABC):
+    """Base class for implementing a unit of work."""
+
+    session: AsyncSession
+
+    async def __aenter__(self) -> "AbstractUnitOfWork":
+        self.session = await self._get_session()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        if exc:
+            await self.rollback()
+        else:
+            await self.commit()
+        await self.session.close()
+
+    async def commit(self) -> None:
+        await self.session.commit()
+
+    async def rollback(self) -> None:
+        await self.session.rollback()
+
+    @abstractmethod
+    async def _get_session(self) -> AsyncSession:
+        ...
+
+
+class SqlAlchemyUnitOfWork(AbstractUnitOfWork):
+    """Default SQLAlchemy implementation."""
+
+    async def _get_session(self) -> AsyncSession:
+        return SessionFactory()
+
+
+__all__ = ["AbstractUnitOfWork", "SqlAlchemyUnitOfWork"]

--- a/fastapi-modmonolith/app/worker/__init__.py
+++ b/fastapi-modmonolith/app/worker/__init__.py
@@ -1,0 +1,1 @@
+"""Background workers for the modular monolith."""

--- a/fastapi-modmonolith/app/worker/outbox_worker.py
+++ b/fastapi-modmonolith/app/worker/outbox_worker.py
@@ -1,0 +1,22 @@
+"""Simple async worker that would process outbox messages."""
+
+from __future__ import annotations
+
+import asyncio
+
+from ..config import get_settings
+from ..logging import get_logger
+
+
+async def run_outbox_worker() -> None:
+    settings = get_settings()
+    logger = get_logger(__name__)
+    poll_interval = settings.outbox_poll_ms / 1000
+    logger.info("outbox_worker_started", poll_interval=poll_interval)
+    while True:  # pragma: no cover - illustrative
+        await asyncio.sleep(poll_interval)
+        logger.debug("outbox_worker_tick")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_outbox_worker())

--- a/fastapi-modmonolith/docker-compose.yml
+++ b/fastapi-modmonolith/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.9"
+services:
+  app:
+    build: .
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./:/app
+    env_file:
+      - ./.env.example
+    depends_on:
+      - db
+      - redis
+  worker:
+    build: .
+    command: python -m app.worker.outbox_worker
+    env_file:
+      - ./.env.example
+    depends_on:
+      - db
+      - redis
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: app
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+    ports:
+      - "5432:5432"
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"

--- a/fastapi-modmonolith/pyproject.toml
+++ b/fastapi-modmonolith/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "fastapi-modmonolith"
+version = "0.1.0"
+description = "FastAPI modular monolith with DDD, in-process events, outbox, tenancy, OIDC hook"
+requires-python = ">=3.12"
+dependencies = [
+  "fastapi>=0.115",
+  "uvicorn[standard]>=0.30",
+  "pydantic>=2.7",
+  "pydantic-settings>=2.2",
+  "SQLAlchemy>=2.0",
+  "alembic>=1.13",
+  "asyncpg>=0.29",
+  "psycopg[binary]>=3.2",
+  "structlog>=24.1",
+  "orjson>=3.10",
+  "authlib>=1.3",
+  "python-jose[cryptography]>=3.3",
+  "httpx>=0.27",
+  "tenacity>=8.5",
+  "redis>=5.0",
+  "fastapi-limiter>=0.1.6",
+  "typing-extensions>=4.12"
+]
+
+[tool.uvicorn]
+reload = true
+factory = false
+host = "0.0.0.0"
+port = 8000
+
+[tool.black]
+line-length = 100
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- scaffold a modular FastAPI application with configuration, logging, tenancy middleware, and shared infrastructure utilities
- add domain, application, infrastructure, and presentation layers for users and blog modules with example routes and handlers
- provide project tooling including Docker, docker-compose, Makefile targets, Alembic setup, and example environment variables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbd082ccfc8329adeb32ca3fd0ffdf